### PR TITLE
Fixed bug

### DIFF
--- a/mercury_app/models.py
+++ b/mercury_app/models.py
@@ -102,11 +102,11 @@ class Merchandise(models.Model):
     quantity = models.IntegerField(default=0)
     value = models.CharField(max_length=16)
 
-    @property
-    def quantity_handed(self):
+    def quantity_handed(self, date):
         return Transaction.objects.filter(
             merchandise__id=self.id,
-            operation_type='HA').count()
+            operation_type='HA',
+            date=date).count()
 
     def __string__(self):
         return self.name
@@ -126,7 +126,7 @@ class Transaction(models.Model):
         ('HA', 'Hand'),
         ('RE', 'Refund'),
     )
-    date = models.DateTimeField(auto_now_add=True)
+    date = models.DateTimeField(auto_now_add=False)
     from_who = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,

--- a/mercury_app/tests.py
+++ b/mercury_app/tests.py
@@ -156,23 +156,37 @@ MOCK_EVENT_API = {
 class TestMerchandise(TestCase):
     def test_quantity_handed(self):
         merchandise = MerchandiseFactory()
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        result = merchandise.quantity_handed
+        date = datetime.now(tz=timezone.utc)
+        TransactionFactory(
+            merchandise=merchandise, operation_type='HA', date=date)
+        result = merchandise.quantity_handed(date)
         self.assertEqual(result, 1)
 
     def test_quantity_handed_two(self):
         merchandise = MerchandiseFactory()
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        result = merchandise.quantity_handed
+        date = datetime.now(tz=timezone.utc)
+        TransactionFactory(merchandise=merchandise,
+                           operation_type='HA',
+                           date=date)
+        TransactionFactory(merchandise=merchandise,
+                           operation_type='HA',
+                           date=date)
+        result = merchandise.quantity_handed(date)
         self.assertEqual(result, 2)
 
     def test_quantity_handed_three(self):
         merchandise = MerchandiseFactory()
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        TransactionFactory(merchandise=merchandise, operation_type='HA')
-        result = merchandise.quantity_handed
+        date = datetime.now(tz=timezone.utc)
+        TransactionFactory(merchandise=merchandise,
+                           operation_type='HA',
+                           date=date)
+        TransactionFactory(merchandise=merchandise,
+                           operation_type='HA',
+                           date=date)
+        TransactionFactory(merchandise=merchandise,
+                           operation_type='HA',
+                           date=date)
+        result = merchandise.quantity_handed(date)
         self.assertEqual(result, 3)
 
 
@@ -399,7 +413,8 @@ class UtilsTest(TestCase):
         order = OrderFactory(id=20, email="algun@email.com")
         merchandises = [MerchandiseFactory(
             name="Gorra", item_type="Roja", order=order)]
-        result = get_merchas_for_email(merchandises)
+        date = datetime.now(tz=timezone.utc)
+        result = get_merchas_for_email(merchandises, date)
         expected = ([["Gorra", "Roja", 0]], 20, "algun@email.com")
         self.assertEqual(expected, result)
 
@@ -407,9 +422,11 @@ class UtilsTest(TestCase):
         order = OrderFactory(id=20, email="algun@email.com")
         merchandises = [MerchandiseFactory(
             name="Gorra", item_type="Azul", order=order)]
+        date = datetime.now(tz=timezone.utc)
         TransactionFactory(merchandise=merchandises[0],
-                           operation_type='HA')
-        result = get_merchas_for_email(merchandises)
+                           operation_type='HA',
+                           date=date)
+        result = get_merchas_for_email(merchandises, date)
         expected = ([["Gorra", "Azul", 1]], 20, "algun@email.com")
         self.assertEqual(expected, result)
 
@@ -612,8 +629,9 @@ class UtilsTest(TestCase):
         self.assertEqual(result[0], None)
 
     def test_create_transaction(self):
+        date = datetime.now(tz=timezone.utc)
         tx = create_transaction(
-            UserFactory(), MerchandiseFactory(), 'TEST NOTE', 'iPhone', 'HA')
+            UserFactory(), MerchandiseFactory(), 'TEST NOTE', 'iPhone', 'HA', date)
         self.assertTrue(isinstance(tx, Transaction))
         self.assertEqual(tx.notes, 'TEST NOTE')
 

--- a/mercury_app/utils.py
+++ b/mercury_app/utils.py
@@ -659,7 +659,7 @@ def get_summary_orders(event):
     return data_json
 
 
-def create_transaction(user, merchandise, note, device, operation):
+def create_transaction(user, merchandise, note, device, operation, date):
     try:
         tx = Transaction.objects.create(
             merchandise=merchandise,
@@ -667,6 +667,7 @@ def create_transaction(user, merchandise, note, device, operation):
             notes=note,
             device_name=device,
             operation_type=operation,
+            date=date,
         )
         update_db_merch_status(tx.merchandise.order)
         return tx
@@ -783,14 +784,14 @@ def send_email_alert(transactions, email, date, operation, order_id):
         return context
 
 
-def get_merchas_for_email(merchases):
+def get_merchas_for_email(merchases, date):
     merchandises = []
     merchases_ids = []
     for mercha in merchases:
         if mercha.id not in merchases_ids:
             merchandises.append([mercha.name,
                                  mercha.item_type,
-                                 mercha.quantity_handed,
+                                 mercha.quantity_handed(date),
                                  ])
             merchases_ids.append(mercha.id)
     return merchandises, mercha.order.id, mercha.order.email

--- a/mercury_app/views.py
+++ b/mercury_app/views.py
@@ -9,6 +9,8 @@ from django.http import HttpResponse
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django_tables2 import SingleTableMixin, SingleTableView
 import json
+from django.utils import timezone
+from datetime import datetime
 from mercury_app.models import (
     Organization,
     UserOrganization,
@@ -161,6 +163,7 @@ class ListItemMerchandising(TemplateView, LoginRequiredMixin, OrderAccessMixin):
         data = self.request.POST
         keys = list(data)[:-2]
         merchases = []
+        date = datetime.now(tz=timezone.utc)
         for item in keys:
             for qty in range(int(data[item])):
                 mercha = Merchandise.objects.get(
@@ -172,9 +175,10 @@ class ListItemMerchandising(TemplateView, LoginRequiredMixin, OrderAccessMixin):
                     data['comment'],
                     'unique',
                     'HA',
+                    date,
                 )
                 merchases.append(mercha)
-        merchandises, order_id, email = get_merchas_for_email(merchases)
+        merchandises, order_id, email = get_merchas_for_email(merchases, transaction.date)
         date = transaction.date.strftime("%Y-%m-%d %H:%M:%S")
         operation = transaction.operation_type
         send_email_alert.delay(json.dumps(merchandises),


### PR DESCRIPTION
**Bug** 🐛 
_email_
We was sending the total delivery per type, now we send the total delivery per type in that specific time (transactions made in that specific time). 