### PR TITLE
Fix coveralls commit msg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - docker-compose build
 
 script:
-  - docker-compose run -e COVERALLS_REPO_TOKEN=$repo_token django bash -c "coverage run manage.py test && coveralls"
+  - docker-compose run -e TRAVIS=true -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -e COVERALLS_REPO_TOKEN="$repo_token" django bash -c "coverage run manage.py test && coveralls"


### PR DESCRIPTION
After we moved to docker, the commit details were not making it to coveralls. This fixes that.

We are still getting the following exception, but everything is working properly nonetheless.

`Submitting coverage to coveralls.io... Failed collecting git data. Are you running coveralls inside a git repository? Traceback (most recent call last): File "/usr/local/lib/python3.6/site-packages/coveralls/git.py", line 68, in git_info 'id': gitlog('%H'), File "/usr/local/lib/python3.6/site-packages/coveralls/git.py", line 30, in gitlog '--pretty=format:{}'.format(fmt)) File "/usr/local/lib/python3.6/site-packages/coveralls/git.py", line 19, in run_command cmd.returncode, stdout, stderr)) coveralls.exception.CoverallsException: command return code 128, STDOUT: "b''" STDERR: "b'fatal: Not a git repository (or any parent up to mount point /app)\nStopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n'" Coverage submitted!`